### PR TITLE
fix(union): should use max of right board

### DIFF
--- a/lib/union.js
+++ b/lib/union.js
@@ -33,7 +33,7 @@ module.exports = function union(ranges) {
             if (currentRandge.from <= previousRandge.to) {
                 return previousRandges.concat({
                     from: previousRandge.from,
-                    to: currentRandge.to
+                    to: Math.max(previousRandge.to, currentRandge.to)
                 });
             } else {
                 return previousRandges.concat(previousRandge, currentRandge);

--- a/test/union.test.js
+++ b/test/union.test.js
@@ -93,3 +93,15 @@ test('should union ranges with equal right board', function(t) {
 
     t.deepEqual(unitedRanges, [{ from: 10, to: 20 }]);
 });
+
+test('should union ranges with right board in reverse order', function(t) {
+    var ranges = [
+        { from: 9, to: 20 },
+        { from: 10, to: 15 },
+        { from: 11, to: 10 }
+    ];
+
+    var unitedRanges = union(ranges);
+
+    t.deepEqual(unitedRanges, [{ from: 9, to: 20 }]);
+});

--- a/test/union.test.js
+++ b/test/union.test.js
@@ -99,7 +99,7 @@ test('should union ranges with right board in reverse order', function(t) {
         { from: 9, to: 20 },
         { from: 10, to: 15 },
         { from: 11, to: 10 }
-    ];
+    ]; 
 
     var unitedRanges = union(ranges);
 

--- a/test/union.test.js
+++ b/test/union.test.js
@@ -69,3 +69,27 @@ test('should not union almost boundary ranges', function(t) {
 
     t.deepEqual(unitedRanges, ranges);
 });
+
+test('should union ranges with equal left board', function(t) {
+    var ranges = [
+        { from: 10, to: 20 },
+        { from: 10, to: 15 },
+        { from: 10, to: 10 }
+    ];
+
+    var unitedRanges = union(ranges);
+
+    t.deepEqual(unitedRanges, [{ from: 10, to: 20 }]);
+});
+
+test('should union ranges with equal right board', function(t) {
+    var ranges = [
+        { from: 10, to: 20 },
+        { from: 15, to: 20 },
+        { from: 20, to: 20 }
+    ];
+
+    var unitedRanges = union(ranges);
+
+    t.deepEqual(unitedRanges, [{ from: 10, to: 20 }]);
+});


### PR DESCRIPTION
Resolved #4 

**Example**

``` js
const ranges = [
    { from: 10, to: 20 },
    { from: 10, to: 15 },
    { from: 10, to: 10 }
];

const unitedRanges = union(ranges);
```

**Before fix**

``` js
[{ from: 10, to: 10 }]
```

**Expected**

``` js
[{ from: 10, to: 20 }]
```
